### PR TITLE
feat: Dify API 스트리밍 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bin/
 ### deploy ###
 **/build_and_push.ps1**
 **/build_and_push_test.ps1**
+/deploy-dev
 
 ## for env ##
 *.env

--- a/sora-webflux/build.gradle
+++ b/sora-webflux/build.gradle
@@ -41,6 +41,13 @@ dependencies {
     implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 
+    // Jackson Java 8 Date/Time Support
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // Netty DNS resolver for MacOS (optional, removes warning)
+    if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+        implementation 'io.netty:netty-resolver-dns-native-macos:4.1.100.Final:osx-aarch_64'
+    }
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/sora-webflux/src/main/java/magicofconch/sorawebflux/config/WebClientConfig.java
+++ b/sora-webflux/src/main/java/magicofconch/sorawebflux/config/WebClientConfig.java
@@ -4,6 +4,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 @Configuration
 public class WebClientConfig {
 
@@ -11,5 +14,11 @@ public class WebClientConfig {
     public WebClient webClient() {
         return WebClient.builder().build();
     }
-}
 
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}

--- a/sora-webflux/src/main/java/magicofconch/sorawebflux/review/controller/SoraController.java
+++ b/sora-webflux/src/main/java/magicofconch/sorawebflux/review/controller/SoraController.java
@@ -1,16 +1,17 @@
 package magicofconch.sorawebflux.review.controller;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import magicofconch.sorawebflux.review.dto.ReviewRes;
-import magicofconch.sorawebflux.review.dto.SubmitReq;
-import magicofconch.sorawebflux.review.service.SoraService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import magicofconch.sorawebflux.review.dto.ReviewRes;
+import magicofconch.sorawebflux.review.dto.SubmitReq;
+import magicofconch.sorawebflux.review.service.SoraService;
 import reactor.core.publisher.Flux;
 
 @Slf4j
@@ -18,18 +19,39 @@ import reactor.core.publisher.Flux;
 @RequiredArgsConstructor
 public class SoraController {
 
-    private final String BEARER_TOKEN = "Bearer ";
+	private final String BEARER_TOKEN = "Bearer ";
 
-    private final SoraService soraService;
+	private final SoraService soraService;
 
-    @PostMapping(value = "/stream/review",
-            consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.TEXT_EVENT_STREAM_VALUE
-    )
-    public Flux<ReviewRes> streamReview(@RequestBody SubmitReq req, ServerHttpRequest request) {
-        String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-        String token = (authHeader != null && authHeader.startsWith(BEARER_TOKEN)) ? authHeader.substring(BEARER_TOKEN.length()) : null;
+	@PostMapping(value = "/stream/review",
+		consumes = MediaType.APPLICATION_JSON_VALUE,
+		produces = MediaType.TEXT_EVENT_STREAM_VALUE
+	)
+	public Flux<ReviewRes> streamReview(@RequestBody SubmitReq req, ServerHttpRequest request) {
+		String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+		String token =
+			(authHeader != null && authHeader.startsWith(BEARER_TOKEN)) ? authHeader.substring(BEARER_TOKEN.length()) :
+				null;
 
-        return soraService.streamReview(req, token);
-    }
+		return soraService.streamReview(req, token);
+	}
+
+	/**
+	 *
+	 * @param req - 회고 리뷰 요청
+	 * @param request - Http Request
+	 * @return - tokens through SSE
+	 */
+	@PostMapping(value = "/stream/review/dify",
+		consumes = MediaType.APPLICATION_JSON_VALUE,
+		produces = MediaType.TEXT_EVENT_STREAM_VALUE
+	)
+	public Flux<ReviewRes> streamReviewWithDify(@RequestBody SubmitReq req, ServerHttpRequest request) {
+		String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+		String token =
+			(authHeader != null && authHeader.startsWith(BEARER_TOKEN)) ? authHeader.substring(BEARER_TOKEN.length()) :
+				null;
+
+		return soraService.streamReviewWithDify(req, token);
+	}
 }

--- a/sora-webflux/src/main/java/magicofconch/sorawebflux/review/service/SoraService.java
+++ b/sora-webflux/src/main/java/magicofconch/sorawebflux/review/service/SoraService.java
@@ -1,5 +1,7 @@
 package magicofconch.sorawebflux.review.service;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.springframework.ai.openai.OpenAiChatModel;
@@ -10,6 +12,9 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,18 +30,21 @@ import reactor.core.publisher.Flux;
 @RequiredArgsConstructor
 public class SoraService {
 
+	private static final String DIFY_API_URL = "https://api.dify.ai/v1/chat-messages";
 	private final OpenAiChatModel chatClient;
 	private final WebClient webClient;
 	private final JwtUtil jwtUtil;
-
+	private final ObjectMapper objectMapper;
 	@Value("${prompt.sora-type.T}")
 	private String promptAsT;
-
 	@Value("${prompt.sora-type.F}")
 	private String promptAsF;
-
 	@Value("${sora.srv.url}")
 	private String appServer;
+	@Value("${dify.api-key.T}")
+	private String difyApiKeyT;
+	@Value("${dify.api-key.F}")
+	private String difyApiKeyF;
 
 	/**
 	 * open-ai 스트리밍 메서드
@@ -69,6 +77,83 @@ public class SoraService {
 	}
 
 	/**
+	 * Dify 스트리밍 메서드
+	 *
+	 * @param req
+	 * @param token
+	 * @return
+	 */
+	public Flux<ReviewRes> streamReviewWithDify(SubmitReq req, String token) {
+		if (token == null || !jwtUtil.validateToken(token) || jwtUtil.isExpired(token)) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized");
+		}
+
+		String username = jwtUtil.getUsername(token);
+		String apiKey = (req.getType() == FeedbackType.FEELING ? difyApiKeyF : difyApiKeyT);
+
+		// Dify API 요청 바디 구성
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("inputs", Map.of("name", username));
+		requestBody.put("query", req.getBody());
+		requestBody.put("response_mode", "streaming");
+		requestBody.put("conversation_id", "");
+		requestBody.put("user", username);
+		requestBody.put("auto_save", false);
+		requestBody.put("disable_history", true);
+
+		AtomicReference<StringBuilder> bufferRef = new AtomicReference<>(new StringBuilder());
+		AtomicReference<Integer> seqRef = new AtomicReference<>(0);
+
+		return webClient.post()
+			.uri(DIFY_API_URL)
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(requestBody)
+			.retrieve()
+			.bodyToFlux(String.class)
+			.doOnNext(line -> log.debug("Dify raw response: {}", line))
+			.flatMap(data -> {
+				try {
+					// SSE 형식이면 "data: " 제거
+					String jsonData = data.startsWith("data: ") ? data.substring(6).trim() : data.trim();
+
+					if (jsonData.isEmpty() || jsonData.equals("[DONE]")) {
+						return Flux.empty();
+					}
+
+					JsonNode jsonNode = objectMapper.readTree(jsonData);
+					String event = jsonNode.path("event").asText();
+
+					if ("message".equals(event)) {
+						String answer = jsonNode.path("answer").asText("");
+						if (!answer.isEmpty()) {
+							bufferRef.get().append(answer);
+							return Flux.just(ReviewRes.builder()
+								.seq(seqRef.getAndUpdate(i -> i + 1))
+								.value(answer)
+								.build());
+						}
+					} else if ("message_end".equals(event)) {
+						log.info("Dify streaming completed");
+					}
+					return Flux.empty();
+				} catch (Exception e) {
+					log.error("Error parsing Dify response: {}", data, e);
+					return Flux.empty();
+				}
+			})
+			.doOnComplete(() -> {
+				String feedback = bufferRef.get().toString();
+				log.info("Dify complete feedback: {}", feedback);
+				sendToServer(req, feedback, token);
+			})
+			.doOnError(error -> {
+				log.error("Dify streaming error", error);
+			});
+	}
+
+	/**
+	 * 서버에 리뷰 저장
 	 *
 	 * @param req
 	 * @param feedback

--- a/sora-webflux/src/main/resources/application.yml
+++ b/sora-webflux/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
         options:
           model: ${OPEN_AI_MODEL}
         project-id: ${OPEN_AI_PROJECT}
+
+logging:
+  level:
+    magicofconch.sorawebflux.review.service.SoraService: DEBUG
+
 jwt:
   secret: ${JWT_SECRET}
   expiration:
@@ -21,3 +26,8 @@ jwt:
 sora:
   srv:
     url: ${SORA_SRV_URL}
+
+dify:
+  api-key:
+    F: ${DIFY_F_API_KEY}
+    T: ${DIFY_T_API_KEY}


### PR DESCRIPTION
### Summary
Dify API 스트리밍 기능 구현

### Description

**변경 사항**
- Dify Chat Messages API 연동 추가
- WebFlux 기반 SSE 스트리밍 구현
- F/T 타입별 Dify API 키 설정 지원

**주요 파일**
- `SoraService.java`: streamReviewWithDify() 메서드 추가
- `SoraController.java`: POST /stream/review/dify 엔드포인트 추가
- `application.yml`: dify.api-key.F/T 설정 추가
- `build.gradle`: jackson-datatype-jsr310 의존성 추가
- `WebClientConfig.java`: ObjectMapper Bean 및 JavaTimeModule 설정

**API 스펙**
- Endpoint: POST /stream/review/dify
- Content-Type: application/json
- Response: text/event-stream
- 요청 형식: Dify Chat Messages API 표준 준수
- 응답 파싱: message 이벤트의 answer 필드 스트리밍

**기술 스택**
- Spring WebFlux
- Dify API v1
- Jackson for JSON parsing
- Reactive Streams

**테스트**
- 기존 OpenAI 엔드포인트 유지 (/stream/review)
- Dify 엔드포인트 추가 (/stream/review/dify)
- 동일한 ReviewRes 응답 구조